### PR TITLE
A couple small updates 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+    - 1.5
+    - tip
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 gcm
 ===
+[![Build Status](https://travis-ci.org/drichardson/gcm.svg)](https://travis-ci.org/drichardson/gcm?branch=master)
 
 The Android SDK provides a nice convenience library ([com.google.android.gcm.server](https://github.com/google/gcm/tree/master/client-libraries/java/rest-client/src/com/google/android/gcm/server)) that greatly simplifies the interaction between Java-based application servers and Google's GCM servers. However, Google has not provided much support for application servers implemented in languages other than Java, specifically those written in the Go programming language. The `gcm` package helps to fill in this gap, providing a simple interface for sending GCM messages and automatically retrying requests in case of service unavailability.
 

--- a/message.go
+++ b/message.go
@@ -12,6 +12,7 @@ type Message struct {
 	TimeToLive            int                    `json:"time_to_live,omitempty"`
 	RestrictedPackageName string                 `json:"restricted_package_name,omitempty"`
 	DryRun                bool                   `json:"dry_run,omitempty"`
+	ContentAvailable      bool                   `json:"content_available,omitempty"`
 }
 
 // NewMessage returns a new Message with the specified payload

--- a/sender.go
+++ b/sender.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// GcmSendEndpoint is the endpoint for sending messages to the GCM server.
-	GcmSendEndpoint = "https://android.googleapis.com/gcm/send"
+	GcmSendEndpoint = "https://gcm-http.googleapis.com/gcm/send"
 	// Initial delay before first retry, without jitter.
 	backoffInitialDelay = 1000
 	// Maximum delay before a retry.


### PR DESCRIPTION
The [Google Cloud Messaging documentation](https://developers.google.com/cloud-messaging/) specifies a new send endpoint URL.

Also, to send notifications to iOS, I exposed the optional ContentAvailable field.

Tests pass.

```
$ go test
PASS
ok      github.com/drichardson/gcm  3.339s
```

Also verified in my own project that iOS receives the push notifications.
