### PR TITLE
FCM support added.

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// GcmSendEndpoint is the endpoint for sending messages to the GCM server.
-	GcmSendEndpoint = "https://android.googleapis.com/gcm/send"
+	GcmSendEndpoint = "https://fcm.googleapis.com/fcm/send"
 	// Initial delay before first retry, without jitter.
 	backoffInitialDelay = 1000
 	// Maximum delay before a retry.


### PR DESCRIPTION
FCM is backward compatible with GCM, so GCM messages and tokens will still work with this endpoint